### PR TITLE
[modify] layout server and page components

### DIFF
--- a/apps/website/src/lib/types/resume.ts
+++ b/apps/website/src/lib/types/resume.ts
@@ -7,10 +7,90 @@ export type Content = {
 };
 
 export type Resume = {
-  profile: object;
-  contacts: object;
-  skills: { [key: string]: { title: string; professional: Content[]; casual: Content[] } };
-  experiences: object;
-  educations: object;
-  languages: object;
+  profile: {
+    name: string;
+    fullName: string;
+    job: string;
+    image: string;
+    themeColour: string;
+    showPhoto: boolean;
+  };
+  summary: string;
+  contacts: Array<{
+    href: string;
+    type: string;
+    text: string;
+    printText?: string;
+  }>;
+  experiences: Array<{
+    title: string;
+    subtitle: string;
+    timeline: string;
+    location: string;
+    summary: string;
+    tasks: Array<string>;
+  }>;
+  educations: Array<{
+    title: string;
+    timeline: string;
+    location: string;
+  }>;
+  skills: {
+    languages: {
+      title: string;
+      professional: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+      casual: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+    };
+    techs: {
+      title: string;
+      professional: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+      casual: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+    };
+    clouds: {
+      title: string;
+      professional: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+      casual: Array<{
+        percentage: number;
+        title: string;
+        contents: Array<string>;
+      }>;
+    };
+  };
+  languages: Array<{
+    title: string;
+    percentage: number;
+  }>;
+  references: Array<{
+    name: string;
+    title: string;
+    company: string;
+    mobile: {
+      href: string;
+      text: string;
+    };
+    email: {
+      href: string;
+      text: string;
+    };
+  }>;
 };

--- a/apps/website/src/routes/resume/[slug]/+page.svelte
+++ b/apps/website/src/routes/resume/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   import LinkedIn from '~icons/skill-icons/linkedin';
   import Mobile from '~icons/fluent/call-20-regular';
   import { base } from '$app/paths';
+  import { type Resume } from '$lib/types/resume';
   import ProgressBar from '$lib/components/ProgressBar.svelte';
   import { Accordion, AccordionItem } from '@skeletonlabs/skeleton';
   import { onMount } from 'svelte';
@@ -15,7 +16,7 @@
     github: GitHub,
     linkedin: LinkedIn,
   };
-  $: ({ profile, contacts, experiences, educations, skills, languages, references, summary } = data.resume);
+  $: ({ profile, contacts, experiences, educations, skills, languages, references, summary } = data.resume as Resume);
   onMount(() => {
     window.onbeforeprint = () => {
       document.getElementById('page').scrollTo(0, 0);
@@ -66,7 +67,7 @@
       <div class="grid break-inside-auto gap-4">
         {#each Object.values(skills) as skillSet}
           {#if skillSet.title}
-            <strong class="text-md">{skillSet.title}</strong>
+            <strong class="text-md">{skillSet?.title}</strong>
           {/if}
           <div class="grid gap-2">
             {#each skillSet.professional as item}

--- a/apps/website/src/routes/skills/+page.server.ts
+++ b/apps/website/src/routes/skills/+page.server.ts
@@ -1,4 +1,4 @@
-import type { LayoutServerLoad } from './$types';
+import type { PageServerLoad } from './$types';
 import { request, gql } from 'graphql-request';
 import { GITHUB_TOKEN } from '$env/static/private';
 type StorageRepo = {
@@ -42,12 +42,13 @@ export const load = (async () => {
     { owner: 'huantrinh1802', name: 'file_storage' },
     { Authorization: `Bearer ${GITHUB_TOKEN}` }
   );
-  return repositories.repository.object.entries.reduce((current, entry) => {
-    if (entry.name == 'ben_resume.json') {
-      return { ...current, 'ben-trinh': JSON.parse(entry.object.text) };
-    }
-    if (entry.name == 'amber_resume.json') {
-      return { ...current, 'amber-duong': JSON.parse(entry.object.text) };
-    }
-  }, {});
-}) satisfies LayoutServerLoad;
+  return {
+    resume: JSON.parse(
+      repositories.repository.object.entries.find((entry) => {
+        if (entry.name == 'ben_resume.json') {
+          return entry;
+        }
+      }).object.text
+    ),
+  };
+}) satisfies PageServerLoad;

--- a/apps/website/src/routes/skills/+page.svelte
+++ b/apps/website/src/routes/skills/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import resume from '$contents/ben-trinh/resume.json';
   import Close from '~icons/icon-park/close';
   import SkillBanner, { type Skill } from '$lib/components/SkillBanner.svelte';
   import { type Resume } from '$lib/types/resume';
+  export let data;
   let dialog: HTMLDialogElement;
   let currentContent = 'Python';
-  const { skills }: Resume = resume;
+  const { skills } = data.resume as Resume;
   let displayContents = [];
   Object.values(skills).forEach((skillSet) => {
     skillSet.professional.map((item) => {


### PR DESCRIPTION
- Implement GraphQL request to fetch resume data from Github in `layout.server.ts`
- Add support for fetching resumes for Ben Trinh and Amber Duong from the file_storage repository
- Define resume type and modify data binding in `page.svelte`
- Safeguard against missing skillSet title in `page.svelte`