### PR TITLE
fix: correct the output path for .env file in GitHub workflows

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ${{ env.BUILD_PATH }}
       - name: Build SvelteKit
         run: |
-          echo "GH_TOKEN=$GH_TOKEN\nPUBLIC_SITE_URL=$PUBLIC_SITE_URL" >> ./apps/website/.env
+          echo "GH_TOKEN=$GH_TOKEN\nPUBLIC_SITE_URL=$PUBLIC_SITE_URL" >> ./.env
           pnpm build
         working-directory: ${{ env.BUILD_PATH }}
         env:

--- a/.github/workflows/sveltekit.yml
+++ b/.github/workflows/sveltekit.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ${{ env.BUILD_PATH }}
       - name: Build SvelteKit
         run: |
-          echo "GH_TOKEN=$GH_TOKEN\nPUBLIC_SITE_URL=$PUBLIC_SITE_URL" >> ./apps/website/.env
+          echo "GH_TOKEN=$GH_TOKEN\nPUBLIC_SITE_URL=$PUBLIC_SITE_URL" >> ./.env
           pnpm build
         working-directory: ${{ env.BUILD_PATH }}
         env:


### PR DESCRIPTION
- Changed the output path for the .env file from `./apps/website/.env` to `./.env` in `staging.yml` and `sveltekit.yml`.