### PR TITLE
Add build step for SvelteKit in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,3 +34,11 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.GH_TOKEN}}
           PUBLIC_SITE_URL: 'http://localhost:5173'
+      - name: Build SvelteKit
+        run: |
+          echo "GH_TOKEN=$GH_TOKEN\nPUBLIC_SITE_URL=$PUBLIC_SITE_URL" >> ./.env
+          pnpm build
+        working-directory: ${{ env.BUILD_PATH }}
+        env:
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          PUBLIC_SITE_URL: ${{ steps.pages.outputs.base_url }}


### PR DESCRIPTION
- Append GH_TOKEN and PUBLIC_SITE_URL to .env file
- Run build command for SvelteKit using pnpm
- Use the specified BUILD_PATH as the working directory
- Utilize the base URL output from the 'pages' step for PUBLIC_SITE_URL