### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/huantrinh1802/BenTriByte/security/code-scanning/1](https://github.com/huantrinh1802/BenTriByte/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, builds, and runs linters, it only needs read access to repository contents. The best way to do this is to add `permissions: { contents: read }` at the top level of the workflow (just after the `name:` key and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
